### PR TITLE
Publish reward hacking indicators blog post

### DIFF
--- a/content-blog/reward-hacking-indicators.md
+++ b/content-blog/reward-hacking-indicators.md
@@ -5,7 +5,7 @@ description: "Using importance sampling with fine-tuned donor prefills to predic
 author: ["David Johnston"]
 ShowToc: true
 mathjax: true
-draft: true
+draft: false
 ---
 
 # Abstract


### PR DESCRIPTION
## Summary
- Sets `draft: false` in the reward hacking indicators blog post frontmatter so it appears on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)