### PR TITLE
Fix author/date meta rendering literal &nbsp; after Hugo 0.127 bump

### DIFF
--- a/themes/eai-base/layouts/partials/post_meta.html
+++ b/themes/eai-base/layouts/partials/post_meta.html
@@ -13,5 +13,5 @@
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end -}}


### PR DESCRIPTION
## Problem

After #154 merged, the author/date line on blog list / archive / post pages renders literal `&nbsp;·&nbsp;` instead of a middot separator, and author apostrophes are double-escaped (e.g. `O&#39;Brien` shows as `O&amp;#39;Brien`).

## Root cause

#154 bumped `HUGO_VERSION` `0.109.0 → 0.127.0` in `netlify.toml`. Newer Hugo's `html/template` escaping now escapes the plain string returned by `delimit . "&nbsp;·&nbsp;"` in `themes/eai-base/layouts/partials/post_meta.html`, so `&nbsp;` becomes `&amp;nbsp;` on output. The partial itself was unchanged — the version bump exposed the latent issue.

## Fix

Append `| safeHTML` to the delimited output — the same pattern already used in `breadcrumbs.html`. Since `post_meta.html` is the shared meta partial, this fixes archives, list, home, single, and index pages at once.

## Verification

Built locally with Hugo 0.127.0 (`hugo --config config-blog.toml`) against current `master`:
- Meta renders `July 13, 2026&nbsp;·&nbsp;David Johnston` (proper non-breaking spaces + middot)
- Author apostrophes render correctly (`Kyle O'Brien`)
- Zero `&amp;nbsp;` remain anywhere in built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)